### PR TITLE
Update documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ MONGO_URI=mongodb://your.mongodb.server:27017/ireversi
 PORT=3025
 ```
 
-### API documents (Staging)
+### API documents
 
-[Document for iReversi API v2](https://stg-server.ireversi.io/api-docs/v2/). (Using [Swagger](https://swagger.io/docs/))
+[Document for iReversi API v2](https://server.ireversi.io/api-docs/v2/). (Using [Swagger](https://swagger.io/docs/))

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,6 +135,13 @@
     consola "^1.4.4"
     http-proxy-middleware "^0.19.0"
 
+"@nuxtjs/toast@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/toast/-/toast-3.0.1.tgz#20ea4eeb15dbac12d9967e85b809ca49c8a14cf5"
+  integrity sha1-IOpO6xXbrBLZln6FuAnKScihTPU=
+  dependencies:
+    vue-toasted "^1.1.24"
+
 "@nuxtjs/youch@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@nuxtjs/youch/-/youch-4.2.3.tgz#36f8b22df5a0efaa81373109851e1d857aca6bed"
@@ -1193,7 +1200,7 @@ babel-polyfill@6.23.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-preset-env@^1.6.0:
+babel-preset-env@^1.6.0, babel-preset-env@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
   integrity sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==
@@ -10369,6 +10376,11 @@ vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
   integrity sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==
+
+vue-toasted@^1.1.24:
+  version "1.1.25"
+  resolved "https://registry.yarnpkg.com/vue-toasted/-/vue-toasted-1.1.25.tgz#27b1f40866d98f8bf817722869f3d97f7c0d4db1"
+  integrity sha512-EAblMFv1Bwq552vvgzd+T2r2UFDAKj0Z8z9EcJpweU7qyKU3OMIkz5S2m6aIFMM507H8VmSJPQHsA/FGbsKp5g==
 
 vue-touch@^2.0.0-beta.4:
   version "2.0.0-beta.4"


### PR DESCRIPTION
- `README.md` の API documents のURL を本番環境のURLに変更
- 下記コミットで追加された `babel-preset-env` を `yarn.lock` ファイルに反映
  [add: babel-preset-env · ireversi/ireversi@565f650](https://github.com/ireversi/ireversi/commit/565f650b8440bc7776f8648f6a9ad7005cb9d731)