### PR TITLE
Update Environment variable of @nuxtjs/google-analytics

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -49,7 +49,7 @@ module.exports = {
     // Doc: https://github.com/nuxt-community/axios-module#usage
     '@nuxtjs/axios',
     '@nuxtjs/toast',
-    ...(NODE_ENV === 'production' ? [['@nuxtjs/google-analytics', { id: GOOGLE_ANALYTICS }]] : []),
+    ...(GOOGLE_ANALYTICS ? [['@nuxtjs/google-analytics', { id: GOOGLE_ANALYTICS }]] : []),
   ],
   /*
   ** Axios module configuration


### PR DESCRIPTION
@nuxtjs/google-analytics を使用するか `NODE_ENV` の状態ではなく `GOOGLE_ANALYTICS` の環境変数の有無で判定するように更新