### PR TITLE
ユーザー数のテスト追加

### DIFF
--- a/api/src/models/v2/BoardStore.js
+++ b/api/src/models/v2/BoardStore.js
@@ -11,7 +11,7 @@ const sleep = time => new Promise(resolve => setTimeout(resolve, time));
   while (true) {
     userCounts = onlineUsers.length;
     onlineUsers.length = 0;
-    await sleep(5000);
+    await sleep(2000);
   }
 })();
 
@@ -33,5 +33,9 @@ module.exports = {
       size,
       userCounts,
     };
+  },
+  resetUserCounts() {
+    onlineUsers.length = 0;
+    userCounts = 0;
   },
 };


### PR DESCRIPTION
### ユーザー数のテスト追加
- 2秒ごとにユーザー数が更新される
- 4秒後にユーザー数がリセットされている
### ユーザー数の更新周期変更
- 5秒ごと->2秒ごと
### ユーザー数のリセット処理追加
- テスト前の初期化用