### PR TITLE
テスト関数をtestUtilに集約し、それに伴ってboard.testを修正しました。

### DIFF
--- a/api/src/models/v2/UserModel.js
+++ b/api/src/models/v2/UserModel.js
@@ -5,7 +5,7 @@ const { Schema } = mongoose;
 const UserSchema = new Schema({
   accessToken: String,
   userId: String,
-  username: String,
+  userName: String,
 });
 
 module.exports = mongoose.model('UserModel', UserSchema);

--- a/api/src/models/v2/UserStore.js
+++ b/api/src/models/v2/UserStore.js
@@ -21,7 +21,13 @@ module.exports = {
     });
     return true;
   },
-  getUserData() {
-    return users;
+  // getUserData() {
+  getUserData(user) {
+    if (user === undefined) { return users; }
+    if (user.userId) { return users.find(u => u.userId === user.userId); }
+    if (user.userName) { return users.find(u => u.userName === user.userName); }
+    if (user.accessToken) { return users.find(u => u.accessToken === user.accessToken); }
+    return null;
+    // return users;
   },
 };

--- a/api/src/models/v2/UserStore.js
+++ b/api/src/models/v2/UserStore.js
@@ -10,8 +10,10 @@ module.exports = {
     const User = new UserModel(userData);
     await User.save();
   },
-  DeleteUserData() {
+  async deleteAllUserData() {
     users.length = 0;
+    const User = new UserModel();
+    await User.remove();
   },
   initUserData(userMongo) {
     userMongo.forEach((elm) => {
@@ -21,18 +23,5 @@ module.exports = {
   },
   getUserData() {
     return users;
-  },
-  searchDuplication(userId) {
-    let dup = 0;
-    let flag = false;
-    users.forEach((elm) => {
-      if (elm.userId === userId) {
-        dup += 1;
-      }
-    });
-    if (dup > 0) {
-      flag = true;
-    }
-    return flag;
   },
 };

--- a/api/src/routes/api/v2/topScore/index.js
+++ b/api/src/routes/api/v2/topScore/index.js
@@ -10,7 +10,7 @@ function searchUserName(userId) {
       name = 'origin';
     }
     if (elm.userId === userId) {
-      name = elm.username;
+      name = elm.userName;
     }
   });
   return name;
@@ -28,7 +28,7 @@ function convertRanking(result, number) {
   // userIdの各々について検索。score計算。
   idsArr.forEach(async (elm) => {
     let score = 0;
-    const username = searchUserName(elm);
+    const userName = searchUserName(elm);
     result.forEach((cnt) => {
       if (elm === cnt) {
         score += 1;
@@ -37,7 +37,7 @@ function convertRanking(result, number) {
     const idscore = {
       userId: elm,
       score,
-      username,
+      userName,
     };
     scores.push(idscore);
   });

--- a/api/src/routes/api/v2/userIdGenerate/index.js
+++ b/api/src/routes/api/v2/userIdGenerate/index.js
@@ -7,22 +7,22 @@ router.route('/').post((req, res) => {
   const ans = {};
   const accessToken = generateToken.generate();
   const { userId } = jwt.decode(accessToken);
-  const { username } = req.body;
+  const { userName } = req.body;
 
-  // 正規表現でusernameのvalidation
+  // 正規表現でuserNameのvalidation
   // 数値、アルファベット、_以外が出たらtrueを返す正規表現
   const reg = /^[a-z0-9]([_a-z0-9]){2,13}[a-z0-9]$/;
 
   // 禁止文字の検索、最短の検索、最長の検索
-  if (reg.test(username) && username !== null && username !== undefined) {
+  if (reg.test(userName) && userName !== null && userName !== undefined) {
     ans.accessToken = accessToken;
     ans.userId = userId;
-    ans.username = username;
+    ans.userName = userName;
     UserStore.addUserData(ans);
   } else {
     ans.accessToken = null;
     ans.userId = null;
-    ans.username = null;
+    ans.userName = null;
   }
   res.json(ans);
 });

--- a/api/src/utils/testUtil.js
+++ b/api/src/utils/testUtil.js
@@ -1,6 +1,18 @@
+const chai = require('chai');
 const PieceStore = require('../models/v2/PieceStore.js');
+const UserStore = require('../models/v2/UserStore.js');
+const BoardStore = require('../models/v2/BoardStore.js');
+const app = require('../routes/app.js');
+
+const basePath = '/api/v2';
 
 module.exports = {
+  initTestParameter() {
+    PieceStore.deletePieces();
+    UserStore.deleteAllUserData();
+    BoardStore.resetUserCounts();
+  },
+
   array2PieceMatchers(array) {
     const size = Math.sqrt(array.length);
     return (array.map((p, idx) => (p !== 0 ? {
@@ -29,5 +41,18 @@ module.exports = {
         });
       }
     });
+  },
+
+  async setTestUsers(num) {
+    const testUsers = [];
+    for (let i = 0; i < num; i += 1) {
+      const username = `test${String(i)}`;
+      const response = await chai.request(app)
+        .post(`${basePath}/user_id_generate`)
+        .set('content-type', 'application/x-www-form-urlencoded')
+        .send({ username });
+      testUsers.push(response.body);
+    }
+    return testUsers;
   },
 };

--- a/api/src/utils/testUtil.js
+++ b/api/src/utils/testUtil.js
@@ -1,4 +1,6 @@
 const chai = require('chai');
+const storePlayHistory = require('../utils/storePlayHistory');
+const sendMongo = require('../utils/sendMongo.js');
 const PieceStore = require('../models/v2/PieceStore.js');
 const UserStore = require('../models/v2/UserStore.js');
 const BoardStore = require('../models/v2/BoardStore.js');
@@ -6,11 +8,96 @@ const app = require('../routes/app.js');
 
 const basePath = '/api/v2';
 
+async function putPieces(pieceOrder) {
+  const putResult = [];
+  for (let i = 0; i < pieceOrder.length; i += 1) {
+    const response = await chai.request(app)
+      .post(`${basePath}/piece/`)
+      .set('content-type', 'application/x-www-form-urlencoded')
+      .set('Authorization', UserStore.getUserData({ userId: pieceOrder[i].userId }).accessToken)
+      .send(pieceOrder[i]);
+    putResult.push(response.body);
+  }
+  return putResult;
+}
+
+async function makePlayOrder(pieces) {
+  const array = [];
+  const size = Math.sqrt(pieces.length);
+  pieces.forEach((p, idx) => {
+    if (!Array.isArray(p)) {
+      if (p !== 0) {
+        array.push({
+          n: +p.split(':')[1],
+          piece: {
+            x: Math.floor(idx % size) - Math.floor(size / 2),
+            y: Math.floor(idx / size) - Math.floor(size / 2),
+            userId: `test${p.split(':')[0]}`,
+          },
+        });
+      }
+    } else {
+      p.forEach((u) => {
+        if (u !== 0) {
+          array.push({
+            n: +u.split(':')[1],
+            piece: {
+              x: Math.floor(idx % size) - Math.floor(size / 2),
+              y: Math.floor(idx / size) - Math.floor(size / 2),
+              userId: `test${u.split(':')[0]}`,
+            },
+          });
+        }
+      });
+    }
+  });
+  return array.sort((a, b) => a.n - b.n).map(p => p.piece);
+}
+
+async function makeTestMatchers(pieces) {
+  const array = [];
+  const size = Math.sqrt(pieces.length);
+  pieces.forEach((p, idx) => {
+    if (!Array.isArray(p)) {
+      if (p !== 0) {
+        array.push({
+          n: +p.split(':')[1],
+          status: p.split(':')[2] === 'T',
+          piece: {
+            x: Math.floor(idx % size) - Math.floor(size / 2),
+            y: Math.floor(idx / size) - Math.floor(size / 2),
+            userId: UserStore.getUserData({ userName: `test${p.split(':')[0]}` }).userId,
+          },
+        });
+      }
+    } else {
+      p.forEach((u) => {
+        if (u !== 0) {
+          array.push({
+            n: +u.split(':')[1],
+            status: u.split(':')[2] === 'T',
+            piece: {
+              x: Math.floor(idx % size) - Math.floor(size / 2),
+              y: Math.floor(idx / size) - Math.floor(size / 2),
+              userId: UserStore.getUserData({ userName: `test${u.split(':')[0]}` }).userId,
+            },
+          });
+        }
+      });
+    }
+  });
+  return array.sort((a, b) => a.n - b.n).map(p => ({ status: p.status, piece: p.piece }));
+}
+
+
 module.exports = {
   initTestParameter() {
     PieceStore.deletePieces();
+    // await chai.request(app).delete(`${basePath}`);
     UserStore.deleteAllUserData();
     BoardStore.resetUserCounts();
+    storePlayHistory.deleteStandbySendMongo();
+    sendMongo.startSendingMongo();
   },
 
   array2PieceMatchers(array) {
@@ -18,7 +105,7 @@ module.exports = {
     return (array.map((p, idx) => (p !== 0 ? {
       x: Math.floor(idx % size) - Math.floor(size / 2),
       y: Math.floor(idx / size) - Math.floor(size / 2),
-      userId: p,
+      userId: p === 1 ? 1 : UserStore.getUserData({ userName: `test${p}` }).userId,
     } : p))).filter(p => p !== 0);
   },
 
@@ -30,29 +117,69 @@ module.exports = {
     } : p))).filter(p => p !== 0);
   },
 
-  setTesPieces(pieces) {
-    const size = Math.sqrt(pieces.length);
-    pieces.forEach((p, idx) => {
-      if (p !== 0) {
-        PieceStore.addPiece({
-          x: Math.floor(idx % size) - Math.floor(size / 2),
-          y: Math.floor(idx / size) - Math.floor(size / 2),
-          userId: p,
-        });
-      }
-    });
+  async getBoardPieces(useName) {
+    const response = await chai.request(app)
+      .get(`${basePath}/board/`)
+      .set('Authorization', UserStore.getUserData({ userName: `test${useName}` }).accessToken);
+    return response.body;
+  },
+
+  getTestUserInfo(useName) {
+    return UserStore.getUserData({ userName: `test${useName}` });
+  },
+
+  getAllTestUserInfo() {
+    return UserStore.getUserData();
+  },
+
+  setTestMatchers(pieces) {
+    return makeTestMatchers(pieces);
   },
 
   async setTestUsers(num) {
     const testUsers = [];
     for (let i = 0; i < num; i += 1) {
-      const username = `test${String(i)}`;
       const response = await chai.request(app)
         .post(`${basePath}/user_id_generate`)
         .set('content-type', 'application/x-www-form-urlencoded')
-        .send({ username });
+        .send({ userName: `testu${i}` });
       testUsers.push(response.body);
     }
     return testUsers;
   },
+
+  async setTesPieces2(pieces) {
+    const pieceOrder = await makePlayOrder(pieces);
+    return putPieces(pieceOrder.map(p => ({
+      x: p.x,
+      y: p.y,
+      userId: UserStore.getUserData({ userName: p.userId }).userId,
+    })));
+  },
 };
+
+
+// function makePlayOrder(pieces) {
+//   const size = Math.sqrt(pieces.length);
+//   return pieces.map((p, idx) => (Array.isArray(p) ? p : [p])
+//     .map(u => (u === 0 ? 0 : {
+//       n: +u.split(':')[1],
+//       piece: {
+//         x: Math.floor(idx % size) - Math.floor(size / 2),
+//         y: Math.floor(idx / size) - Math.floor(size / 2),
+//         userId: u.split(':')[0],
+//       },
+//     })).filter(e => e !== 0)).filter(e => e.length !== 0);
+// }
+
+// async function setTestUsers(userList) {
+//   const testUsers = [];
+//   for (let i = 0; i < userList.length; i += 1) {
+//     const response = await chai.request(app)
+//       .post(`${basePath}/user_id_generate`)
+//       .set('content-type', 'application/x-www-form-urlencoded')
+//       .send({ userName: userList[i] });
+//     testUsers.push(response.body);
+//   }
+//   return testUsers;
+// }

--- a/api/src/utils/testUtil.js
+++ b/api/src/utils/testUtil.js
@@ -1,0 +1,33 @@
+const PieceStore = require('../models/v2/PieceStore.js');
+
+module.exports = {
+  array2PieceMatchers(array) {
+    const size = Math.sqrt(array.length);
+    return (array.map((p, idx) => (p !== 0 ? {
+      x: Math.floor(idx % size) - Math.floor(size / 2),
+      y: Math.floor(idx / size) - Math.floor(size / 2),
+      userId: p,
+    } : p))).filter(p => p !== 0);
+  },
+
+  array2CandidateMatchers(array) {
+    const size = Math.sqrt(array.length);
+    return (array.map((p, idx) => (p !== 0 ? {
+      x: Math.floor(idx % size) - Math.floor(size / 2),
+      y: Math.floor(idx / size) - Math.floor(size / 2),
+    } : p))).filter(p => p !== 0);
+  },
+
+  setTesPieces(pieces) {
+    const size = Math.sqrt(pieces.length);
+    pieces.forEach((p, idx) => {
+      if (p !== 0) {
+        PieceStore.addPiece({
+          x: Math.floor(idx % size) - Math.floor(size / 2),
+          y: Math.floor(idx / size) - Math.floor(size / 2),
+          userId: p,
+        });
+      }
+    });
+  },
+};

--- a/api/swagger/v2/swagger.yml
+++ b/api/swagger/v2/swagger.yml
@@ -345,7 +345,7 @@ definitions:
     summary: "generate new userId by JWT"
     description: "userIdの新規生成"
     parameters:
-      - name: username
+      - name: userName
         in: "formData"
         description: "input user name"
         type: string

--- a/api/tests/routes/api/v2/board/board.test.js
+++ b/api/tests/routes/api/v2/board/board.test.js
@@ -1,10 +1,10 @@
-const chai = require('chai');
-const app = require('../../../../../src/routes/app.js');
+
 const testUtil = require('../../../../../src/utils/testUtil');
 
-const basePath = '/api/v2/board';
 const ZERO = 0;
+const ZERO00 = 0;
 const INIT = 1;
+const CENTER = 0;
 
 const sleep = time => new Promise(resolve => setTimeout(resolve, time));
 
@@ -16,34 +16,31 @@ describe('check board pieces', () => {
 
     // Given
     const userNumber = 10;
-    const testUsers = await testUtil.setTestUsers(userNumber);
-    const u = n => testUsers[n].userId;
+    await testUtil.setTestUsers(userNumber);
 
     const putPieces = [
-      ZERO, ZERO, ZERO, ZERO, ZERO,
-      ZERO, u(0), u(1), u(2), ZERO,
-      ZERO, u(3), INIT, u(4), ZERO,
-      ZERO, u(5), u(6), u(7), ZERO,
-      ZERO, ZERO, ZERO, ZERO, ZERO,
+      ZERO00, ZERO00, ZERO00, ZERO00, ZERO00,
+      ZERO00, 'u0:8', 'u1:1', 'u2:2', ZERO00,
+      ZERO00, 'u3:7', CENTER, 'u4:3', ZERO00,
+      ZERO00, 'u5:6', 'u6:5', 'u7:4', ZERO00,
+      ZERO00, ZERO00, ZERO00, ZERO00, ZERO00,
     ];
-    testUtil.setTesPieces(putPieces);
 
     const pieceMatchers = testUtil.array2PieceMatchers([
       ZERO, ZERO, ZERO, ZERO, ZERO,
-      ZERO, u(0), u(1), u(2), ZERO,
-      ZERO, u(3), INIT, u(4), ZERO,
-      ZERO, u(5), u(6), u(7), ZERO,
+      ZERO, 'u0', 'u1', 'u2', ZERO,
+      ZERO, 'u3', INIT, 'u4', ZERO,
+      ZERO, 'u5', 'u6', 'u7', ZERO,
       ZERO, ZERO, ZERO, ZERO, ZERO,
     ]);
 
     // When
-    const response = await chai.request(app)
-      .get(`${basePath}`)
-      .set('Authorization', testUsers[0].accessToken);
+    await testUtil.setTesPieces2(putPieces);
+    const boardPieces = await testUtil.getBoardPieces('u0');
 
     // Then
-    expect(response.body.pieces).toHaveLength(pieceMatchers.length);
-    expect(response.body.pieces).toEqual(expect.arrayContaining(pieceMatchers));
+    expect(boardPieces.pieces).toHaveLength(pieceMatchers.length);
+    expect(boardPieces.pieces).toEqual(expect.arrayContaining(pieceMatchers));
   });
 });
 
@@ -54,45 +51,43 @@ describe('check board pieces and candidates', () => {
 
     // Given
     const userNumber = 10;
-    const testUsers = await testUtil.setTestUsers(userNumber);
-    const u = n => testUsers[n].userId;
+    await testUtil.setTestUsers(userNumber);
 
     const putPieces = [
-      ZERO, ZERO, ZERO, ZERO, ZERO,
-      ZERO, ZERO, ZERO, ZERO, ZERO,
-      ZERO, ZERO, INIT, ZERO, ZERO,
-      ZERO, ZERO, u(0), ZERO, ZERO,
-      ZERO, ZERO, ZERO, ZERO, ZERO,
+      ZERO00, ZERO00, ZERO00, ZERO00, ZERO00,
+      ZERO00, ZERO00, ZERO00, ZERO00, ZERO00,
+      ZERO00, ZERO00, CENTER, ZERO00, ZERO00,
+      ZERO00, ZERO00, 'u0:1', ZERO00, ZERO00,
+      ZERO00, ZERO00, ZERO00, ZERO00, ZERO00,
     ];
-    testUtil.setTesPieces(putPieces);
 
     const pieceMatchers = testUtil.array2PieceMatchers([
       ZERO, ZERO, ZERO, ZERO, ZERO,
       ZERO, ZERO, ZERO, ZERO, ZERO,
       ZERO, ZERO, INIT, ZERO, ZERO,
-      ZERO, ZERO, u(0), ZERO, ZERO,
+      ZERO, ZERO, 'u0', ZERO, ZERO,
       ZERO, ZERO, ZERO, ZERO, ZERO,
     ]);
 
     const candidateMatchers = testUtil.array2CandidateMatchers([
       ZERO, ZERO, ZERO, ZERO, ZERO,
-      ZERO, ZERO, u(1), ZERO, ZERO,
-      ZERO, u(1), ZERO, u(1), ZERO,
-      ZERO, u(1), ZERO, u(1), ZERO,
-      ZERO, ZERO, u(1), ZERO, ZERO,
+      ZERO, ZERO, 'u1', ZERO, ZERO,
+      ZERO, 'u1', ZERO, 'u1', ZERO,
+      ZERO, 'u1', ZERO, 'u1', ZERO,
+      ZERO, ZERO, 'u1', ZERO, ZERO,
     ]);
 
     // When
-    const response = await chai.request(app)
-      .get(`${basePath}`)
-      .set('Authorization', testUsers[1].accessToken);
+    await testUtil.setTesPieces2(putPieces);
+    const boardPieces = await testUtil.getBoardPieces('u1');
+
     // Then
     // 置かれた駒のチェック
-    expect(response.body.pieces).toHaveLength(pieceMatchers.length);
-    expect(response.body.pieces).toEqual(expect.arrayContaining(pieceMatchers));
+    expect(boardPieces.pieces).toHaveLength(pieceMatchers.length);
+    expect(boardPieces.pieces).toEqual(expect.arrayContaining(pieceMatchers));
     // セットされたtestUserに対する駒を置ける場所のチェック
-    expect(response.body.candidates).toHaveLength(candidateMatchers.length);
-    expect(response.body.candidates).toEqual(expect.arrayContaining(candidateMatchers));
+    expect(boardPieces.candidates).toHaveLength(candidateMatchers.length);
+    expect(boardPieces.candidates).toEqual(expect.arrayContaining(candidateMatchers));
   });
 });
 
@@ -103,23 +98,19 @@ describe('the number of online users', () => {
 
     // Given
     const userNumber = 10;
-    const testUsers = await testUtil.setTestUsers(userNumber);
+    await testUtil.setTestUsers(userNumber);
     const time = 2000;
 
-    for (let i = 0; i < testUsers.length; i += 1) {
-      await chai.request(app)
-        .get(`${basePath}`)
-        .set('Authorization', testUsers[i].accessToken);
+    for (let i = 0; i < userNumber; i += 1) {
+      await testUtil.getBoardPieces(`u${String(i)}`);
     }
 
     // When
     await sleep(time);
-    const response = await chai.request(app)
-      .get(`${basePath}`)
-      .set('Authorization', testUsers[0].accessToken);
+    const boardPieces = await testUtil.getBoardPieces('u0');
 
     // Then
-    expect(response.body.userCounts).toEqual(userNumber);
+    expect(boardPieces.userCounts).toEqual(userNumber);
   });
 
   it('is reset the number of online users after 4 seconds from last request', async () => {
@@ -128,21 +119,18 @@ describe('the number of online users', () => {
 
     // Given
     const userNumber = 10;
-    const testUsers = await testUtil.setTestUsers(userNumber);
+    await testUtil.setTestUsers(userNumber);
     const time = 4000;
-    for (let i; i < testUsers.length; i += 1) {
-      await chai.request(app)
-        .get(`${basePath}`)
-        .set('Authorization', testUsers[i].accessToken);
+
+    for (let i = 0; i < userNumber; i += 1) {
+      await testUtil.getBoardPieces(`u${String(i)}`);
     }
 
     // When
     await sleep(time);
-    const response = await chai.request(app)
-      .get(`${basePath}`)
-      .set('Authorization', testUsers[userNumber - 1].accessToken);
+    const boardPieces = await testUtil.getBoardPieces('u9');
 
     // Then
-    expect(response.body.userCounts).toEqual(0);
+    expect(boardPieces.userCounts).toEqual(0);
   });
 });

--- a/api/tests/routes/api/v2/piece/piece.test.js
+++ b/api/tests/routes/api/v2/piece/piece.test.js
@@ -1,11 +1,5 @@
-const chai = require('chai');
-const jwt = require('jsonwebtoken');
-const PieceStore = require('../../../../../src/models/v2/PieceStore.js');
-const array2Pieces = require('../../../../../src/utils/array2Pieces.js');
-const array2Matchers = require('../../../../../src/utils/array2Matchers.js');
-const app = require('../../../../../src/routes/app.js');
 const BoardHistoryModel = require('../../../../../src/models/v2/BoardHistoryModel.js');
-const storePlayHistory = require('../../../../../src/utils/storePlayHistory');
+const testUtil = require('../../../../../src/utils/testUtil');
 
 const sendMongo = require('../../../../../src/utils/sendMongo.js');
 
@@ -15,33 +9,16 @@ const {
   stopDB,
 } = require('../../../../../src/utils/db.js');
 
-const generateToken = require('../../../../../src/routes/api/v2/userIdGenerate/generateToken');
 
 const sleep = msec => new Promise(resolve => setTimeout(resolve, msec));
-const basePath = '/api/v2/piece/';
 const propFilter = '-_id -__v';
 
-function genJwtArr(number) {
-  const jwtIds = [];
-  for (i = 0; i < number; i += 1) {
-    const jwtElm = {};
-    tempJwt = generateToken.generate();
-    jwtElm.jwtId = tempJwt;
-    jwtElm.decode = jwt.decode(tempJwt).userId;
-    jwtIds.push(jwtElm);
-  }
-  return jwtIds;
-}
-
-function searchIndex(jwtIds, jwtId) {
-  let ans = -1;
-  jwtIds.forEach((elm, index) => {
-    if (elm.decode === jwtId) {
-      ans = index;
-    }
-  });
-  return ans;
-}
+const ZERO = 0;
+const INIT = 1;
+const ZERO00 = 0;
+const ZERO0000 = 0;
+const CENTER = 0;
+const CENTERRR = 0;
 
 describe('piece', () => {
   beforeAll(prepareDB);
@@ -49,363 +26,449 @@ describe('piece', () => {
   afterAll(stopDB);
 
   describe('piece', () => {
-    // デバッグ検証、candidates残り確認
-    it('cannot be put on the same place3', async () => {
+    // 既に駒が置いてある場所にはおけない。
+    it('cannot be put on the same place', async () => {
       // Reset
-      await chai.request(app).delete(`${basePath}`);
-      PieceStore.deletePieces();
-      storePlayHistory.deleteStandbySendMongo();
-      sendMongo.startSendingMongo();
+      testUtil.initTestParameter();
 
-      const jwtIds = genJwtArr(3);
       // Given
-      const pieces = array2Pieces.array2Pieces(
-        [
-          0, 0, 0,
-          `${jwtIds[0].decode}:1`, [`${jwtIds[1].decode}:2`, `${jwtIds[2].decode}:3`], `${jwtIds[0].decode}:4`,
-          0, 0, 0,
-        ],
-      );
+      const userNumber = 10;
+      await testUtil.setTestUsers(userNumber);
 
-      const matches = array2Matchers.array2Matchers(
-        [
-          0, 0, 0,
-          `${jwtIds[0].decode}:1`, [`${jwtIds[1].decode}:2`, `${jwtIds[2].decode}:3:f`], `${jwtIds[0].decode}:4`,
-          0, 0, 0,
-        ],
-      );
+      const putPieces = [
+        ZERO00, ZERO00, ZERO00, [ZERO00, ZERO00], ZERO00,
+        ZERO00, ZERO00, ZERO00, [ZERO00, ZERO00], ZERO00,
+        ZERO00, ZERO00, CENTER, [ZERO00, ZERO00], ZERO00,
+        ZERO00, ZERO00, 'u0:1', ['u1:2', 'u2:3'], 'u0:4',
+        ZERO00, ZERO00, ZERO00, [ZERO00, ZERO00], ZERO00,
+      ];
+
+      const putJucgeMatches = await testUtil.setTestMatchers([
+        ZERO00, ZERO00, ZERO0000, [ZERO0000, ZERO0000], ZERO0000,
+        ZERO00, ZERO00, ZERO0000, [ZERO0000, ZERO0000], ZERO0000,
+        ZERO00, ZERO00, CENTERRR, [ZERO0000, ZERO0000], ZERO0000,
+        ZERO00, ZERO00, 'u0:1:T', ['u1:2:T', 'u2:3:F'], 'u0:4:T',
+        ZERO00, ZERO00, ZERO0000, [ZERO0000, ZERO0000], ZERO0000,
+      ]);
+
+      const pieceMatchers = testUtil.array2PieceMatchers([
+        ZERO, ZERO, ZERO, ZERO, ZERO,
+        ZERO, ZERO, ZERO, ZERO, ZERO,
+        ZERO, ZERO, INIT, ZERO, ZERO,
+        ZERO, ZERO, 'u0', 'u0', 'u0',
+        ZERO, ZERO, ZERO, ZERO, ZERO,
+      ]);
 
       // MongoDB確認のため、matchesからstatus: falseのオブジェクトを抜いた配列
-      const matchesDB = matches.filter(m => m.status === true);
+      const testMatchesDB = putJucgeMatches.filter(m => m.status === true);
 
       // When
-      let response;
-      for (let i = 0; i < pieces.length; i += 1) {
-        const match = matches[i];
-        const index = searchIndex(jwtIds, pieces[i].piece.userId);
-        response = await chai.request(app)
-          .post(`${basePath}`)
-          .set('content-type', 'application/x-www-form-urlencoded')
-          .set('Authorization', jwtIds[index].jwtId)
-          .send(pieces[i].piece);
+      const testPieces = await testUtil.setTesPieces2(putPieces);
+      const boardPieces = await testUtil.getBoardPieces('u0');
 
-        // Then
-        expect(response.body).toEqual(match);
-        expect(response.body).toEqual(expect.objectContaining({
-          status: match.status,
+      // Then
+      testPieces.forEach((result, i) => {
+        expect(result).toEqual(putJucgeMatches[i]);
+        expect(result).toEqual(expect.objectContaining({
+          status: putJucgeMatches[i].status,
           piece: {
-            x: match.piece.x,
-            y: match.piece.y,
-            userId: match.piece.userId,
+            x: putJucgeMatches[i].piece.x,
+            y: putJucgeMatches[i].piece.y,
+            userId: putJucgeMatches[i].piece.userId,
           },
         }));
-      }
+      });
+
+      expect(boardPieces.pieces).toHaveLength(pieceMatchers.length);
+      expect(boardPieces.pieces).toEqual(expect.arrayContaining(pieceMatchers));
+
       await sleep(2000); // 2000ミリ秒待機
       const pieceData = JSON.parse(JSON.stringify(await BoardHistoryModel.find({}, propFilter)));
-      expect(pieceData).toHaveLength(matchesDB.length);
+      expect(pieceData).toHaveLength(testMatchesDB.length);
 
       // matchesから
-      for (let i = 0; i < matchesDB.length; i += 1) {
-        expect(pieceData).toContainEqual(expect.objectContaining({ piece: matchesDB[i].piece }));
+      for (let i = 0; i < testMatchesDB.length; i += 1) {
+        expect(pieceData).toContainEqual(
+          expect.objectContaining({ piece: testMatchesDB[i].piece }),
+        );
       }
       await sendMongo.stopSendingMongo();
     });
   });
 
 
-  // 初期値があるから1を他の場所に置けない、離れたところに置けないテスト
+  // ２駒目は他の駒を挟まないところには置けない
   it('is put', async () => {
     // Reset
-    await chai.request(app).delete(`${basePath}`);
-    PieceStore.deletePieces();
-    storePlayHistory.deleteStandbySendMongo();
-
-    const jwtIds = genJwtArr(2);
+    testUtil.initTestParameter();
 
     // Given
-    const pieces = array2Pieces.array2Pieces(
-      [
-        `${jwtIds[0].decode}:1`, `${jwtIds[1].decode}:2`,
-        0, `${jwtIds[0].decode}:3`,
-      ],
-    );
+    const userNumber = 10;
+    await testUtil.setTestUsers(userNumber);
 
-    const matches = array2Matchers.array2Matchers(
-      [
-        `${jwtIds[0].decode}:1`, `${jwtIds[1].decode}:2`,
-        0, `${jwtIds[0].decode}:3:f`,
-      ],
-    );
+    // Given
+    const putPieces = [
+      ZERO00, ZERO00, ZERO00, ZERO00, ZERO00,
+      ZERO00, ZERO00, ZERO00, ZERO00, ZERO00,
+      ZERO00, ZERO00, CENTER, ZERO00, ZERO00,
+      ZERO00, ZERO00, 'u0:1', 'u1:2', ZERO00,
+      ZERO00, ZERO00, ZERO00, 'u0:3', ZERO00,
+    ];
+
+    const putJucgeMatches = await testUtil.setTestMatchers([
+      ZERO00, ZERO00, ZERO0000, ZERO0000, ZERO0000,
+      ZERO00, ZERO00, ZERO0000, ZERO0000, ZERO0000,
+      ZERO00, ZERO00, CENTERRR, ZERO0000, ZERO0000,
+      ZERO00, ZERO00, 'u0:1:T', 'u1:2:T', ZERO0000,
+      ZERO00, ZERO00, ZERO0000, 'u0:3:F', ZERO0000,
+    ]);
+
+    const pieceMatchers = testUtil.array2PieceMatchers([
+      ZERO, ZERO, ZERO, ZERO, ZERO,
+      ZERO, ZERO, ZERO, ZERO, ZERO,
+      ZERO, ZERO, INIT, ZERO, ZERO,
+      ZERO, ZERO, 'u0', 'u1', ZERO,
+      ZERO, ZERO, ZERO, ZERO, ZERO,
+    ]);
+
 
     // When
-    let response;
-    for (let i = 0; i < pieces.length; i += 1) {
-      const match = matches[i];
-      const index = searchIndex(jwtIds, pieces[i].piece.userId);
-      response = await chai.request(app)
-        .post(`${basePath}`)
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .set('Authorization', jwtIds[index].jwtId)
-        .send(pieces[i].piece);
+    // MongoDB確認のため、matchesからstatus: falseのオブジェクトを抜いた配列
+    const testMatchesDB = putJucgeMatches.filter(m => m.status === true);
 
-      // Then
-      expect(response.body).toEqual(match);
-      expect(response.body).toEqual(expect.objectContaining({
-        status: match.status,
+    // When
+    const testPieces = await testUtil.setTesPieces2(putPieces);
+    const boardPieces = await testUtil.getBoardPieces('u0');
+
+    // Then
+    testPieces.forEach((result, i) => {
+      expect(result).toEqual(putJucgeMatches[i]);
+      expect(result).toEqual(expect.objectContaining({
+        status: putJucgeMatches[i].status,
         piece: {
-          x: match.piece.x,
-          y: match.piece.y,
-          userId: match.piece.userId,
+          x: putJucgeMatches[i].piece.x,
+          y: putJucgeMatches[i].piece.y,
+          userId: putJucgeMatches[i].piece.userId,
         },
       }));
+    });
+
+    expect(boardPieces.pieces).toHaveLength(pieceMatchers.length);
+    expect(boardPieces.pieces).toEqual(expect.arrayContaining(pieceMatchers));
+
+    await sleep(2000); // 2000ミリ秒待機
+    const pieceData = JSON.parse(JSON.stringify(await BoardHistoryModel.find({}, propFilter)));
+    expect(pieceData).toHaveLength(testMatchesDB.length);
+
+    // matchesから
+    for (let i = 0; i < testMatchesDB.length; i += 1) {
+      expect(pieceData).toContainEqual(expect.objectContaining({ piece: testMatchesDB[i].piece }));
     }
+    await sendMongo.stopSendingMongo();
   });
 
   // 離れたところは置けない1
   it('never become alone (far away from the other pieces)', async () => {
     // Reset
-    await chai.request(app).delete(`${basePath}`);
-    PieceStore.deletePieces();
-    storePlayHistory.deleteStandbySendMongo();
-
-    const jwtIds = genJwtArr(2);
+    testUtil.initTestParameter();
 
     // Given
-    const pieces = array2Pieces.array2Pieces(
-      [
-        `${jwtIds[0].decode}:1`, 0, 0,
-        0, 0, `${jwtIds[1].decode}:4`,
-        0, `${jwtIds[1].decode}:3`, `${jwtIds[1].decode}:2`,
-      ],
-    );
+    const userNumber = 10;
+    await testUtil.setTestUsers(userNumber);
 
-    const matches = array2Matchers.array2Matchers(
-      [
-        `${jwtIds[0].decode}:1:f`, 0, 0,
-        0, 0, `${jwtIds[1].decode}:4:f`,
-        0, `${jwtIds[1].decode}:3`, `${jwtIds[1].decode}:2:f`,
-      ],
-    );
+    const putPieces = [
+      'u0:1', ZERO00, ZERO00,
+      ZERO00, CENTER, 'u1:4',
+      ZERO00, 'u1:3', 'u1:2',
+    ];
+
+    const putJucgeMatches = await testUtil.setTestMatchers([
+      'u0:1:F', ZERO0000, ZERO0000,
+      ZERO0000, CENTERRR, 'u1:4:F',
+      ZERO0000, 'u1:3:T', 'u1:2:F',
+    ]);
+
+    const pieceMatchers = testUtil.array2PieceMatchers([
+      ZERO, ZERO, ZERO,
+      ZERO, INIT, ZERO,
+      ZERO, 'u1', ZERO,
+    ]);
 
     // When
-    let response;
-    for (let i = 0; i < pieces.length; i += 1) {
-      const match = matches[i];
-      const index = searchIndex(jwtIds, pieces[i].piece.userId);
-      response = await chai.request(app)
-        .post(`${basePath}`)
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .set('Authorization', jwtIds[index].jwtId)
-        .send(pieces[i].piece);
-      // Then
-      expect(response.body).toEqual(match);
-      expect(response.body).toEqual(expect.objectContaining({
-        status: match.status,
+    // MongoDB確認のため、matchesからstatus: falseのオブジェクトを抜いた配列
+    const testMatchesDB = putJucgeMatches.filter(m => m.status === true);
+
+    const testPieces = await testUtil.setTesPieces2(putPieces);
+    const boardPieces = await testUtil.getBoardPieces('u0');
+
+    // Then
+    testPieces.forEach((result, i) => {
+      expect(result).toEqual(putJucgeMatches[i]);
+      expect(result).toEqual(expect.objectContaining({
+        status: putJucgeMatches[i].status,
         piece: {
-          x: match.piece.x,
-          y: match.piece.y,
-          userId: match.piece.userId,
+          x: putJucgeMatches[i].piece.x,
+          y: putJucgeMatches[i].piece.y,
+          userId: putJucgeMatches[i].piece.userId,
         },
       }));
+    });
+
+    expect(boardPieces.pieces).toHaveLength(pieceMatchers.length);
+    expect(boardPieces.pieces).toEqual(expect.arrayContaining(pieceMatchers));
+
+    await sleep(2000); // 2000ミリ秒待機
+    const pieceData = JSON.parse(JSON.stringify(await BoardHistoryModel.find({}, propFilter)));
+    expect(pieceData).toHaveLength(testMatchesDB.length);
+
+    // matchesから
+    for (let i = 0; i < testMatchesDB.length; i += 1) {
+      expect(pieceData).toContainEqual(expect.objectContaining({ piece: testMatchesDB[i].piece }));
     }
+    await sendMongo.stopSendingMongo();
   });
 
   // 離れたところは置けない2
   it('never become alone (far away from the other pieces)2', async () => {
     // Reset
-    await chai.request(app).delete(`${basePath}`);
-    PieceStore.deletePieces();
-    storePlayHistory.deleteStandbySendMongo();
-
-    const jwtIds = genJwtArr(2);
+    testUtil.initTestParameter();
 
     // Given
-    const pieces = array2Pieces.array2Pieces(
-      [
-        `${jwtIds[0].decode}:1`, 0, `${jwtIds[1].decode}:2`,
-        0, 0, 0,
-        0, 0, `${jwtIds[1].decode}:3`,
-      ],
-    );
+    const userNumber = 10;
+    await testUtil.setTestUsers(userNumber);
 
-    const matches = array2Matchers.array2Matchers(
-      [
-        `${jwtIds[0].decode}:1:f`, 0, `${jwtIds[1].decode}:2:f`,
-        0, 0, 0,
-        0, 0, `${jwtIds[1].decode}:3:f`,
-      ],
-    );
+    const putPieces = [
+      'u0:1', ZERO00, 'u1:2',
+      ZERO00, CENTER, ZERO00,
+      ZERO00, ZERO00, 'u1:3',
+    ];
+
+    const putJucgeMatches = await testUtil.setTestMatchers([
+      'u0:1:F', ZERO0000, 'u1:2:F',
+      ZERO0000, CENTERRR, ZERO0000,
+      ZERO0000, ZERO0000, 'u1:3:F',
+    ]);
+
+    const pieceMatchers = testUtil.array2PieceMatchers([
+      ZERO, ZERO, ZERO,
+      ZERO, INIT, ZERO,
+      ZERO, ZERO, ZERO,
+    ]);
 
     // When
-    let response;
-    for (let i = 0; i < pieces.length; i += 1) {
-      const match = matches[i];
-      const index = searchIndex(jwtIds, pieces[i].piece.userId);
-      response = await chai.request(app)
-        .post(`${basePath}`)
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .set('Authorization', jwtIds[index].jwtId)
-        .send(pieces[i].piece);
+    // MongoDB確認のため、matchesからstatus: falseのオブジェクトを抜いた配列
+    const testMatchesDB = putJucgeMatches.filter(m => m.status === true);
 
-      // Then
-      expect(response.body).toEqual(match);
-      expect(response.body).toEqual(expect.objectContaining({
-        status: match.status,
+    const testPieces = await testUtil.setTesPieces2(putPieces);
+    const boardPieces = await testUtil.getBoardPieces('u0');
+
+    // Then
+    testPieces.forEach((result, i) => {
+      expect(result).toEqual(putJucgeMatches[i]);
+      expect(result).toEqual(expect.objectContaining({
+        status: putJucgeMatches[i].status,
         piece: {
-          x: match.piece.x,
-          y: match.piece.y,
-          userId: match.piece.userId,
+          x: putJucgeMatches[i].piece.x,
+          y: putJucgeMatches[i].piece.y,
+          userId: putJucgeMatches[i].piece.userId,
         },
       }));
+    });
+
+    expect(boardPieces.pieces).toHaveLength(pieceMatchers.length);
+    expect(boardPieces.pieces).toEqual(expect.arrayContaining(pieceMatchers));
+
+    await sleep(2000); // 2000ミリ秒待機
+    const pieceData = JSON.parse(JSON.stringify(await BoardHistoryModel.find({}, propFilter)));
+    expect(pieceData).toHaveLength(testMatchesDB.length);
+
+    // matchesから
+    for (let i = 0; i < testMatchesDB.length; i += 1) {
+      expect(pieceData).toContainEqual(expect.objectContaining({ piece: testMatchesDB[i].piece }));
     }
+    await sendMongo.stopSendingMongo();
   });
 
   // 盤面で１手目の場合、斜めに置けないテスト
   it('can be put on cell next to the other pieces not on diagle cells', async () => {
     // Reset
-    await chai.request(app).delete(`${basePath}`);
-    PieceStore.deletePieces();
-    storePlayHistory.deleteStandbySendMongo();
-
-    const jwtIds = genJwtArr(5);
+    testUtil.initTestParameter();
 
     // Given
-    const pieces = array2Pieces.array2Pieces(
-      [
-        `${jwtIds[0].decode}:5`, 0, [`${jwtIds[0].decode}:4`, `${jwtIds[4].decode}:7`],
-        `${jwtIds[2].decode}:3`, `${jwtIds[3].decode}:2`, 0,
-        0, `${jwtIds[1].decode}:1`, `${jwtIds[0].decode}:6`,
-      ],
-    );
+    const userNumber = 10;
+    await testUtil.setTestUsers(userNumber);
 
-    const matches = array2Matchers.array2Matchers(
-      [
-        `${jwtIds[0].decode}:5`, 0, [`${jwtIds[0].decode}:4:f`, `${jwtIds[4].decode}:7:f`],
-        `${jwtIds[2].decode}:3`, `${jwtIds[3].decode}:2`, 0,
-        0, `${jwtIds[1].decode}:1`, `${jwtIds[0].decode}:6`,
-      ],
-    );
+    const putPieces = [
+      'u0:5', ZERO00, ['u0:4', 'u4:7'],
+      'u2:3', 'u3:2', ZERO00,
+      ZERO00, 'u1:1', 'u0:6',
+    ];
+
+    const putJucgeMatches = await testUtil.setTestMatchers([
+      'u0:5:T', ZERO0000, ['u0:4:F', 'u4:7:F'],
+      'u2:3:T', 'u3:2:F', ZERO0000,
+      ZERO0000, 'u1:1:T', 'u0:6:T',
+    ]);
+
+    const pieceMatchers = testUtil.array2PieceMatchers([
+      'u0', ZERO, ZERO,
+      'u2', 'u0', ZERO,
+      ZERO, 'u1', 'u0',
+    ]);
 
     // When
-    let response;
-    for (let i = 0; i < pieces.length; i += 1) {
-      const match = matches[i];
-      const index = searchIndex(jwtIds, pieces[i].piece.userId);
-      response = await chai.request(app)
-        .post(`${basePath}`)
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .set('Authorization', jwtIds[index].jwtId)
-        .send(pieces[i].piece);
+    // MongoDB確認のため、matchesからstatus: falseのオブジェクトを抜いた配列
+    const testMatchesDB = putJucgeMatches.filter(m => m.status === true);
 
-      // Then
-      expect(response.body).toEqual(match);
-      expect(response.body).toEqual(expect.objectContaining({
-        status: match.status,
+    const testPieces = await testUtil.setTesPieces2(putPieces);
+    const boardPieces = await testUtil.getBoardPieces('u0');
+
+    // Then
+    testPieces.forEach((result, i) => {
+      expect(result).toEqual(putJucgeMatches[i]);
+      expect(result).toEqual(expect.objectContaining({
+        status: putJucgeMatches[i].status,
         piece: {
-          x: match.piece.x,
-          y: match.piece.y,
-          userId: match.piece.userId,
+          x: putJucgeMatches[i].piece.x,
+          y: putJucgeMatches[i].piece.y,
+          userId: putJucgeMatches[i].piece.userId,
         },
       }));
+    });
+
+    expect(boardPieces.pieces).toHaveLength(pieceMatchers.length);
+    expect(boardPieces.pieces).toEqual(expect.arrayContaining(pieceMatchers));
+
+    await sleep(2000); // 2000ミリ秒待機
+    const pieceData = JSON.parse(JSON.stringify(await BoardHistoryModel.find({}, propFilter)));
+    expect(pieceData).toHaveLength(testMatchesDB.length);
+
+    // matchesから
+    for (let i = 0; i < testMatchesDB.length; i += 1) {
+      expect(pieceData).toContainEqual(expect.objectContaining({ piece: testMatchesDB[i].piece }));
     }
+    await sendMongo.stopSendingMongo();
   });
 
   // 盤面に自コマがない場合、他コマの上下左右だけおける。斜めには置けないテスト。
   it('can be put on a cell next to the other pieces', async () => {
     // Reset
-    await chai.request(app).delete(`${basePath}`);
-    PieceStore.deletePieces();
-    storePlayHistory.deleteStandbySendMongo();
-
-    const jwtIds = genJwtArr(3);
-
+    testUtil.initTestParameter();
 
     // Given
-    const pieces = array2Pieces.array2Pieces(
-      [
-        `${jwtIds[0].decode}:1`, `${jwtIds[1].decode}:4`, 0,
-        0, [`${jwtIds[2].decode}:3`, `${jwtIds[2].decode}:5`], 0,
-        0, 0, `${jwtIds[1].decode}:2`,
-      ],
-    );
+    const userNumber = 10;
+    await testUtil.setTestUsers(userNumber);
 
-    const matches = array2Matchers.array2Matchers(
-      [
-        `${jwtIds[0].decode}:1:f`, `${jwtIds[1].decode}:4:f`, 0,
-        0, [`${jwtIds[2].decode}:3:f`, `${jwtIds[2].decode}:5:f`], 0,
-        0, 0, `${jwtIds[1].decode}:2:f`,
-      ],
-    );
+    const putPieces = [
+      'u0:1', ['u1:4', ZERO00], ZERO00,
+      ZERO00, ['u2:3', 'u2:5'], ZERO00,
+      ZERO00, [ZERO00, ZERO00], 'u1:2',
+    ];
+
+    const putJucgeMatches = await testUtil.setTestMatchers([
+      'u0:1:F', ['u1:4:T', ZERO0000], ZERO0000,
+      ZERO0000, ['u2:3:F', 'u2:5:F'], ZERO0000,
+      ZERO0000, [ZERO0000, ZERO0000], 'u1:2:F',
+    ]);
+
+    const pieceMatchers = testUtil.array2PieceMatchers([
+      ZERO, 'u1', ZERO,
+      ZERO, INIT, ZERO,
+      ZERO, ZERO, ZERO,
+    ]);
 
     // When
-    let response;
-    for (let i = 0; i < pieces.length; i += 1) {
-      const match = matches[i];
-      const index = searchIndex(jwtIds, pieces[i].piece.userId);
-      response = await chai.request(app)
-        .post(`${basePath}`)
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .set('Authorization', jwtIds[index].jwtId)
-        .send(pieces[i].piece);
-      // Then
-      expect(response.body).toEqual(match);
-      expect(response.body).toEqual(expect.objectContaining({
-        status: match.status,
+    // MongoDB確認のため、matchesからstatus: falseのオブジェクトを抜いた配列
+    const testMatchesDB = putJucgeMatches.filter(m => m.status === true);
+
+    const testPieces = await testUtil.setTesPieces2(putPieces);
+    const boardPieces = await testUtil.getBoardPieces('u0');
+
+    // Then
+    testPieces.forEach((result, i) => {
+      expect(result).toEqual(putJucgeMatches[i]);
+      expect(result).toEqual(expect.objectContaining({
+        status: putJucgeMatches[i].status,
         piece: {
-          x: match.piece.x,
-          y: match.piece.y,
-          userId: match.piece.userId,
+          x: putJucgeMatches[i].piece.x,
+          y: putJucgeMatches[i].piece.y,
+          userId: putJucgeMatches[i].piece.userId,
         },
       }));
+    });
+
+    expect(boardPieces.pieces).toHaveLength(pieceMatchers.length);
+    expect(boardPieces.pieces).toEqual(expect.arrayContaining(pieceMatchers));
+
+    await sleep(2000); // 2000ミリ秒待機
+    const pieceData = JSON.parse(JSON.stringify(await BoardHistoryModel.find({}, propFilter)));
+    expect(pieceData).toHaveLength(testMatchesDB.length);
+
+    // matchesから
+    for (let i = 0; i < testMatchesDB.length; i += 1) {
+      expect(pieceData).toContainEqual(expect.objectContaining({ piece: testMatchesDB[i].piece }));
     }
+    await sendMongo.stopSendingMongo();
   });
 
   it('can flip with defalut piece', async () => {
     // Reset
-    await chai.request(app).delete(`${basePath}`);
-    PieceStore.deletePieces();
-    storePlayHistory.deleteStandbySendMongo();
-
-    const jwtIds = genJwtArr(4);
+    testUtil.initTestParameter();
 
     // Given
-    const pieces = array2Pieces.array2Pieces(
-      [
-        0, 0, `${jwtIds[0].decode}:5`,
-        0, `${jwtIds[2].decode}:2`, `${jwtIds[3].decode}:3`,
-        0, `${jwtIds[1].decode}:1`, 0,
-      ],
-    );
+    const userNumber = 10;
+    await testUtil.setTestUsers(userNumber);
 
-    const matches = array2Matchers.array2Matchers(
-      [
-        0, 0, `${jwtIds[0].decode}:5`,
-        0, `${jwtIds[2].decode}:2`, `${jwtIds[3].decode}:3`,
-        0, `${jwtIds[1].decode}:1`, 0,
-      ],
-    );
+    const putPieces = [
+      ZERO00, ZERO00, 'u0:4',
+      ZERO00, 'u2:2', 'u3:3',
+      ZERO00, 'u1:1', ZERO00,
+    ];
+
+    const putJucgeMatches = await testUtil.setTestMatchers([
+      ZERO00, ZERO0000, 'u0:4:T',
+      ZERO00, 'u2:2:F', 'u3:3:T',
+      ZERO00, 'u1:1:T', ZERO0000,
+    ]);
+
+
+    const pieceMatchers = testUtil.array2PieceMatchers([
+      ZERO, ZERO, 'u0',
+      ZERO, INIT, 'u3',
+      ZERO, 'u1', ZERO,
+    ]);
 
     // When
-    let response;
-    for (let i = 0; i < pieces.length; i += 1) {
-      const match = matches[i];
-      const index = searchIndex(jwtIds, pieces[i].piece.userId);
-      response = await chai.request(app)
-        .post(`${basePath}`)
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .set('Authorization', jwtIds[index].jwtId)
-        .send(pieces[i].piece);
+    // MongoDB確認のため、matchesからstatus: falseのオブジェクトを抜いた配列
+    const testMatchesDB = putJucgeMatches.filter(m => m.status === true);
 
-      // Then
-      expect(response.body).toEqual(match);
-      expect(response.body).toEqual(expect.objectContaining({
-        status: match.status,
+    const testPieces = await testUtil.setTesPieces2(putPieces);
+    const boardPieces = await testUtil.getBoardPieces('u0');
+
+    // Then
+    testPieces.forEach((result, i) => {
+      expect(result).toEqual(putJucgeMatches[i]);
+      expect(result).toEqual(expect.objectContaining({
+        status: putJucgeMatches[i].status,
         piece: {
-          x: match.piece.x,
-          y: match.piece.y,
-          userId: match.piece.userId,
+          x: putJucgeMatches[i].piece.x,
+          y: putJucgeMatches[i].piece.y,
+          userId: putJucgeMatches[i].piece.userId,
         },
       }));
+    });
+
+    expect(boardPieces.pieces).toHaveLength(pieceMatchers.length);
+    expect(boardPieces.pieces).toEqual(expect.arrayContaining(pieceMatchers));
+
+    await sleep(2000); // 2000ミリ秒待機
+    const pieceData = JSON.parse(JSON.stringify(await BoardHistoryModel.find({}, propFilter)));
+    expect(pieceData).toHaveLength(testMatchesDB.length);
+
+    // matchesから
+    for (let i = 0; i < testMatchesDB.length; i += 1) {
+      expect(pieceData).toContainEqual(expect.objectContaining({ piece: testMatchesDB[i].piece }));
     }
+    await sendMongo.stopSendingMongo();
   });
 });

--- a/api/tests/routes/api/v2/topScore/getTopScore.test.js
+++ b/api/tests/routes/api/v2/topScore/getTopScore.test.js
@@ -10,21 +10,21 @@ const zero = 0;
 
 function searchUserName(userId) {
   const users = UserStore.getUserData();
-  let userName = 'origin';
+  let username = 'origin';
   users.forEach((elm) => {
     if (elm.userId === userId) {
-      userName = elm.username;
+      username = elm.userName;
     }
   });
-  return userName;
+  return username;
 }
 
-function userIdGenerate(username) {
+function userIdGenerate(userName) {
   const token = generateToken.generate();
   UserStore.addUserData({
     accessToken: token,
     userId: jwt.decode(token).userId,
-    username,
+    userName,
   });
   return token;
 }
@@ -48,7 +48,7 @@ async function convertRanking(result, number) {
   // userIdの各々について検索。score計算。
   idsArr.forEach((elm) => {
     let score = 0;
-    const username = searchUserName(elm);
+    const userName = searchUserName(elm);
     result.forEach((cnt) => {
       if (elm === cnt) {
         score += 1;
@@ -57,7 +57,7 @@ async function convertRanking(result, number) {
     const idscore = {
       userId: elm,
       score,
-      username,
+      userName,
     };
     scores.push(idscore);
   });

--- a/api/tests/routes/api/v2/userIdGenerate/userIdGenerate.test.js
+++ b/api/tests/routes/api/v2/userIdGenerate/userIdGenerate.test.js
@@ -16,13 +16,13 @@ describe('userId generate', () => {
   it('generates userId and request userName', async () => {
     // Given
     const userIdJwt = userIdGenerate();
-    const username = 'testuser';
+    const userName = 'testuser';
 
     // When
     const response = await chai.request(app)
       .post(`${basePath}/user_id_generate`)
       .set('content-type', 'application/x-www-form-urlencoded')
-      .send({ username });
+      .send({ userName });
       // Then
     expect(response.body.accessToken.length).toEqual(userIdJwt.length);
   });
@@ -30,16 +30,16 @@ describe('userId generate', () => {
 
   it('generates userId and request invalid userName', async () => {
     // Given
-    const username = 'test-kimkim';
+    const userName = 'test-kimkim';
 
     // When
     const response = await chai.request(app)
       .post(`${basePath}/user_id_generate`)
       .set('content-type', 'application/x-www-form-urlencoded')
-      .send({ username });
+      .send({ userName });
       // Then
     expect(response.body.accessToken).toEqual(null);
     expect(response.body.userId).toEqual(null);
-    expect(response.body.username).toEqual(null);
+    expect(response.body.userName).toEqual(null);
   });
 });

--- a/api/tests/utils/userStore.test.js
+++ b/api/tests/utils/userStore.test.js
@@ -13,11 +13,11 @@ describe('users', () => {
     // Given
     jwt1 = generateToken.generate();
     id1 = jwt.decode(jwt1).userId;
-    username1 = 'testname';
+    userName1 = 'testname';
     UserStore.addUserData({
       accessToken: jwt1,
       userId: id1,
-      username: username1,
+      userName: userName1,
     });
     await sleep(2000);
     // await Promise.all(matchers.map(m => PieceModel(m).save()));
@@ -27,7 +27,7 @@ describe('users', () => {
     // Then
     expect(response[0].accessToken).toEqual(jwt1);
     expect(response[0].userId).toEqual(id1);
-    expect(response[0].username).toEqual(username1);
+    expect(response[0].userName).toEqual(userName1);
   });
 
 
@@ -36,11 +36,11 @@ describe('users', () => {
     // Given
     jwt2 = generateToken.generate();
     id2 = jwt.decode(jwt1).userId;
-    username2 = 'testname2';
+    userName2 = 'testname2';
     UserStore.addUserData({
       accessToken: jwt2,
       userId: id2,
-      username: username2,
+      userName: userName2,
     });
     // await Promise.all(matchers.map(m => PieceModel(m).save()));
     // When
@@ -48,6 +48,6 @@ describe('users', () => {
     // Then
     expect(response[1].accessToken).toEqual(jwt2);
     expect(response[1].userId).toEqual(id2);
-    expect(response[1].username).toEqual(username2);
+    expect(response[1].userName).toEqual(userName2);
   });
 });

--- a/api/tests/utils/userStore.test.js
+++ b/api/tests/utils/userStore.test.js
@@ -6,7 +6,7 @@ const sleep = msec => new Promise(resolve => setTimeout(resolve, msec));
 
 describe('users', () => {
   // 初期化
-  UserStore.DeleteUserData();
+  UserStore.deleteAllUserData();
 
   // 1プレイヤー分登録する。
   it('can get and add userData', async () => {

--- a/components/Ranking.vue
+++ b/components/Ranking.vue
@@ -9,7 +9,7 @@
           <span class="num">{{ i + 1 }}</span>
         </span>
       </div>
-      <div class="userName">{{ obj.username }}</div>
+      <div class="userName">{{ obj.userName }}</div>
       <div class="score">{{ obj.score }}</div>
     </div>
     <div class="your-score">

--- a/store/index.js
+++ b/store/index.js
@@ -118,10 +118,10 @@ export const mutations = {
     state.dragFlg = false;
     state.touchTime = new Date().getTime();
   },
-  setAccessToken(state, { accessToken, userId, username }) {
+  setAccessToken(state, { accessToken, userId, userName }) {
     state.token = accessToken;
     state.userId = userId;
-    state.userName = username;
+    state.userName = userName;
   },
   setTopScores(state, scores) {
     const copiedTopScores = [...state.topScores];
@@ -129,16 +129,16 @@ export const mutations = {
       copiedTopScores[i] = {};
       copiedTopScores[i].userId = scores[i] ? scores[i].userId : '-';
       copiedTopScores[i].score = scores[i] ? scores[i].score : 0;
-      copiedTopScores[i].username = scores[i] ? scores[i].username : '-';
+      copiedTopScores[i].userName = scores[i] ? scores[i].userName : '-';
     }
     state.topScores = copiedTopScores;
   },
 };
 
 export const actions = {
-  async getAccessToken({ commit, state }, username) {
+  async getAccessToken({ commit, state }, userName) {
     if (!state.token) {
-      const userData = await this.$axios.$post('/user_id_generate', { username });
+      const userData = await this.$axios.$post('/user_id_generate', { userName });
       commit('setAccessToken', userData);
     }
   },

--- a/tests/v2.test.js
+++ b/tests/v2.test.js
@@ -27,7 +27,7 @@ describe('V2 test', () => {
 
   it('sets a board', async () => {
     // Given
-    const USERNAME = 'userName'; // 4文字以上15文字以下、アルファベット小文字、数字、アンダースコアのみ
+    const USERNAME = 'username'; // 4文字以上15文字以下、アルファベット小文字、数字、アンダースコアのみ
     await store.dispatch('getAccessToken', USERNAME);
 
     const { pieces, candidates, standbys } = await store.$axios.$get('/board');

--- a/tests/v2.test.js
+++ b/tests/v2.test.js
@@ -27,7 +27,7 @@ describe('V2 test', () => {
 
   it('sets a board', async () => {
     // Given
-    const USERNAME = 'username'; // 4文字以上15文字以下、アルファベット小文字、数字、アンダースコアのみ
+    const USERNAME = 'userName'; // 4文字以上15文字以下、アルファベット小文字、数字、アンダースコアのみ
     await store.dispatch('getAccessToken', USERNAME);
 
     const { pieces, candidates, standbys } = await store.$axios.$get('/board');


### PR DESCRIPTION
・testUtil
testUtilファイルの追加（以後、ここにテストで利用する汎用メソッドを集約）
Store情報の取得、更新は基本的にこのファイルを通して行う方針とする。
（そもそもStoreを直接いじっていいのかは現在検討中）

・board.test
testUtilを利用したメソッドに修正
Store情報は基本的にtestUtilを通してのみ、取得したり変更したりできるものとする
user情報はテスト側で作成するのではなく、testUtilを通してappからリクエストを投げて発行するように修正

・UserStore
メソッド名の変更
MongoDBのユーザー情報初期化を追加
利用されていないメソッドを削除

//11/23　追記
一旦、切りがいいのでPRします。
testUtilsについてはもう少しリファクタリングする予定です。
以下、変更内容の一覧です。

・testUtilsを追加し、board_testとpiece_testの共通メソッドを集約
・UserModelの「username」を「userName」に変更。これによりフロント側も一部修正
・UserStoreのgetUserData()でuserIdやuserName、accessTokenを検索キーにユーザー情報を取得できるように追記
・piece_testに盤面の結果による比較を追加、MongoDBによる比較が行われていない箇所についてMongoDBの比較を追加
