### PR TITLE
ズーム開始時の挙動修正

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -304,10 +304,10 @@ export default {
       return (position) => {
         // カーソルの下にあるpieceの座標
         const targetPos = {
-          x: Math.round((this.moveDist.x + position.x - this.$window.width / 2)
-                        / this.calcGridWidth()),
-          y: Math.round((this.moveDist.y - position.y + this.$window.height / 2)
-                        / this.calcGridWidth()),
+          x: (this.moveDist.x + position.x - this.$window.width / 2)
+                        / this.calcGridWidth(),
+          y: (this.moveDist.y - position.y + this.$window.height / 2)
+                        / this.calcGridWidth(),
         };
 
         // pieceの中心とカーソルの位置との差分


### PR DESCRIPTION
## 問題点
#26 対応
ズーム開始時、座標のずれが生じる
## 原因
ズームの動作改善をする際
ズームの中心位置を計算する関数で、座標を四捨五入する処理を修正するのを見直し忘れたため
## 改善
四捨五入する処理を修正